### PR TITLE
13 fix update validation logic in donation usage due to account store mapping change

### DIFF
--- a/src/main/java/com/example/mymoo/domain/donationusage/service/impl/DonationUsageServiceImpl.java
+++ b/src/main/java/com/example/mymoo/domain/donationusage/service/impl/DonationUsageServiceImpl.java
@@ -32,7 +32,6 @@ public class DonationUsageServiceImpl implements DonationUsageService {
 
     private final DonationRepository donationRepository;
     private final ChildRepository childRepository;
-    private final StoreRepository storeRepository;
     private final DonationUsageRepository donationUsageRepository;
 
     @Override
@@ -44,11 +43,9 @@ public class DonationUsageServiceImpl implements DonationUsageService {
                 .orElseThrow(() -> new DonationException(DonationExceptionDetails.DONATION_NOT_FOUND));
         Child child = childRepository.findByAccount_Id(donationUsageCreateRequestDto.childAccountId())
                 .orElseThrow(() -> new ChildException(ChildExceptionDetails.CHILD_NOT_FOUND));
-        Store store = storeRepository.findByAccount_Id(storeAccountId)
-            .orElseThrow(() -> new StoreException(StoreExceptionDetails.STORE_NOT_FOUND));
-
+        Store store = donation.getStore();
         // 자신의 가게가 아닌 다른 가게의 후원을 사용하려 할 때
-        if (!Objects.equals(donation.getStore().getId(), store.getId())){
+        if (!Objects.equals(store.getAccount().getId(), storeAccountId)){
             throw new DonationUsageException(DonationUsageExceptionDetails.FORBIDDEN_ACCESS_TO_OTHER_STORE);
         }
 

--- a/src/main/java/com/example/mymoo/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/mymoo/domain/store/repository/StoreRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
     Page<Store> findAllByNameContainsOrAddressContains(String nameKeyword, String addressKeyword, Pageable pageable);
-    Optional<Store> findByAccount_Id(Long storeAccountId);
 }


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #13

## 📝 Work Details
- Updated the validation logic in the donation usage service to handle the new one-to-many relationship between account and store. This change allows for proper validation of donations when multiple stores are associated with a single account.
- Removed the unused repository method Optional<Store> findByAccount_Id(Long storeAccountId); as it was no longer applicable due to the change in mapping.