### PR TITLE
#36 - fix: include donaor's name to donation post api

### DIFF
--- a/src/main/java/com/example/mymoo/domain/donation/controller/DonationController.java
+++ b/src/main/java/com/example/mymoo/domain/donation/controller/DonationController.java
@@ -1,6 +1,7 @@
 package com.example.mymoo.domain.donation.controller;
 
 import com.example.mymoo.domain.donation.dto.request.DonationRequestDto;
+import com.example.mymoo.domain.donation.dto.response.DonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadAccountDonationListResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadDonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadStoreDonationListResponseDto;
@@ -41,22 +42,22 @@ public class DonationController {
     )
     @PostMapping("/stores/{storeId}")
     @PreAuthorize("hasAuthority('DONATOR')")
-    public ResponseEntity<Void> donate(
+    public ResponseEntity<DonationResponseDto> donate(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable Long storeId,
+        @PathVariable("storeId") Long storeId,
         @Valid @RequestBody DonationRequestDto donationRequestDto
     ) {
         Long accountId = userDetails.getAccountId();
 
-        donationService.createDonation(
-            accountId,
-            storeId,
-            donationRequestDto
-        );
-
         return ResponseEntity
             .status(HttpStatus.CREATED)
-            .build();
+            .body(
+                donationService.createDonation(
+                    accountId,
+                    storeId,
+                    donationRequestDto
+                )
+            );
     }
 
     @Operation(
@@ -68,7 +69,7 @@ public class DonationController {
     )
     @GetMapping("/stores/{storeId}")
     public ResponseEntity<ReadStoreDonationListResponseDto> getStoreDonationList(
-        @PathVariable Long storeId,
+        @PathVariable("storeId") Long storeId,
         @PageableDefault(size = 10, sort = "createdAt", direction = Direction.ASC) @Parameter(hidden = true) Pageable pageable
     ) {
         return ResponseEntity
@@ -107,7 +108,7 @@ public class DonationController {
     @PreAuthorize("hasAuthority('DONATOR')")
     public ResponseEntity<ReadDonationResponseDto> getDonation(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable Long donationId
+        @PathVariable("donationId") Long donationId
     ) {
         Long accountId = userDetails.getAccountId();
         return ResponseEntity

--- a/src/main/java/com/example/mymoo/domain/donation/dto/response/DonationResponseDto.java
+++ b/src/main/java/com/example/mymoo/domain/donation/dto/response/DonationResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.mymoo.domain.donation.dto.response;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record DonationResponseDto(
+    @NotBlank
+    String donator
+) {
+
+}

--- a/src/main/java/com/example/mymoo/domain/donation/service/DonationService.java
+++ b/src/main/java/com/example/mymoo/domain/donation/service/DonationService.java
@@ -1,13 +1,14 @@
 package com.example.mymoo.domain.donation.service;
 
 import com.example.mymoo.domain.donation.dto.request.DonationRequestDto;
+import com.example.mymoo.domain.donation.dto.response.DonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadAccountDonationListResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadDonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadStoreDonationListResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface DonationService {
-    void createDonation(
+    DonationResponseDto createDonation(
         final Long accountId,
         final Long storeId,
         final DonationRequestDto donationRequestDto

--- a/src/main/java/com/example/mymoo/domain/donation/service/impl/DonationServiceImpl.java
+++ b/src/main/java/com/example/mymoo/domain/donation/service/impl/DonationServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.mymoo.domain.account.exception.AccountException;
 import com.example.mymoo.domain.account.exception.AccountExceptionDetails;
 import com.example.mymoo.domain.account.repository.AccountRepository;
 import com.example.mymoo.domain.donation.dto.request.DonationRequestDto;
+import com.example.mymoo.domain.donation.dto.response.DonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadAccountDonationListResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadDonationResponseDto;
 import com.example.mymoo.domain.donation.dto.response.ReadStoreDonationListResponseDto;
@@ -42,7 +43,7 @@ public class DonationServiceImpl implements DonationService {
     private final DonationUsageRepository donationUsageRepository;
 
     @Override
-    public void createDonation(
+    public DonationResponseDto createDonation(
         final Long accountId,
         final Long storeId,
         final DonationRequestDto donationRequestDto
@@ -66,6 +67,10 @@ public class DonationServiceImpl implements DonationService {
                 .isUsed(false)
                 .build()
         );
+
+        return DonationResponseDto.builder()
+            .donator(account.getNickname())
+            .build();
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #36

## 📝 Work Details
- Updated the donation response body to include the donor's first and last name.
- Implemented logic to retrieve the donor's name based on the donor ID associated with the donation.
- Updated documentation to reflect changes in the response structure and ensure backward compatibility.
