### PR TITLE
39 feature add validation for donation usage limit per child account

### DIFF
--- a/src/main/java/com/example/mymoo/domain/donationusage/exception/DonationUsageExceptionDetails.java
+++ b/src/main/java/com/example/mymoo/domain/donationusage/exception/DonationUsageExceptionDetails.java
@@ -14,6 +14,8 @@ public enum DonationUsageExceptionDetails implements ExceptionDetails {
     FORBIDDEN_ACCESS_TO_OTHER_STORE(HttpStatus.FORBIDDEN, "해당 후원을 사용할 권한이 없습니다."),
     // 자신이 사용하지 않은 후원권에 대해 후원자에게 감사 메시지를 쓰려 할 때
     FORBIDDEN_TO_WRITE_MESSAGE_TO_OTHER_DONATION(HttpStatus.FORBIDDEN, "해당 후원에 대해 메시지를 작성할 권한이 없습니다."),
+    // 아동이 하루에 3회 이상 후원을 사용하려 할 때
+    EXCEEDED_DAILY_USAGE_LIMIT(HttpStatus.BAD_REQUEST, "아동은 하루에 2회까지만 후원을 사용할 수 있습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/mymoo/domain/donationusage/repository/DonationUsageRepository.java
+++ b/src/main/java/com/example/mymoo/domain/donationusage/repository/DonationUsageRepository.java
@@ -1,9 +1,13 @@
 package com.example.mymoo.domain.donationusage.repository;
 
+import com.example.mymoo.domain.child.entity.Child;
 import com.example.mymoo.domain.donationusage.entity.DonationUsage;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DonationUsageRepository extends JpaRepository<DonationUsage, Long> {
     Optional<DonationUsage> findByDonation_id(Long donationId);
+
+    long countByChildAndCreatedAtBetween(Child child, LocalDateTime start, LocalDateTime end);
 }


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #39

## 📝 Work Details
- Implemented daily usage limit for donation usage by children
- Added logic to check the number of donation usages per child per day
- Created a new method in DonationUsageRepository to count daily usage
- Integrated check for daily usage limit in the useDonation method
- Utilized existing DonationUsageException to handle cases where daily limit is exceeded
- Set maximum daily usage to 2 times per child
- Completed API testing to ensure functionality and correctness of the new feature
