### PR TITLE
50 refactor convert existing jpql queries to querydsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,14 @@ dependencies {
 
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// QueryDSL Implementation
+	// https://mvnrepository.com/artifact/com.querydsl/querydsl-jpa
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	// querydsl JPAAnnotationProcessor 사용 지정
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -54,4 +62,25 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+/**
+ * QueryDSL Build Options
+ */
+// QClass 위치 명시적 지정
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/example/mymoo/domain/donation/repository/CustomDonationRepository.java
+++ b/src/main/java/com/example/mymoo/domain/donation/repository/CustomDonationRepository.java
@@ -1,0 +1,22 @@
+package com.example.mymoo.domain.donation.repository;
+
+import com.example.mymoo.domain.donation.dto.response.DonatorTotalDonationRepositoryDto;
+import com.example.mymoo.domain.donation.entity.Donation;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CustomDonationRepository {
+    Slice<Donation> findRecentDonationsByAccountId(
+        Long accountId,
+        LocalDateTime startDate,
+        Pageable pageable
+    );
+
+    Slice<DonatorTotalDonationRepositoryDto> findDonatorRankings(Pageable pageable);
+
+    Optional<DonatorTotalDonationRepositoryDto> findTotalDonationByAccountId(Long accountId);
+
+    Long findRankByAccountId(Long accountId);
+}

--- a/src/main/java/com/example/mymoo/domain/donation/repository/DonationRepository.java
+++ b/src/main/java/com/example/mymoo/domain/donation/repository/DonationRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface DonationRepository extends JpaRepository<Donation, Long> {
+public interface DonationRepository extends JpaRepository<Donation, Long>, CustomDonationRepository {
     Slice<Donation> findAllByStore_IdAndIsUsedFalse(
         Long storeId,
         Pageable pageable
@@ -20,42 +20,4 @@ public interface DonationRepository extends JpaRepository<Donation, Long> {
         Long accountId,
         Pageable pageable
     );
-
-    @Query("SELECT d FROM Donation d WHERE d.account.id = :accountId " +
-        "AND d.createdAt >= :startDate " +
-        "ORDER BY d.createdAt DESC")
-    Slice<Donation> findRecentDonationsByAccountId(
-        @Param("accountId") Long accountId,
-        @Param("startDate") LocalDateTime startDate,
-        Pageable pageable
-    );
-
-    @Query("SELECT new com.example.mymoo.domain.donation.dto.response.DonatorTotalDonationRepositoryDto(" +
-        "d.account.id, d.account.nickname, d.account.profileImageUrl, SUM(d.point), MAX(d.createdAt)) " +
-        "FROM Donation d " +
-        "GROUP BY d.account.id, d.account.nickname, d.account.profileImageUrl " +
-        "ORDER BY SUM(d.point) DESC, MAX(d.createdAt) DESC, d.account.id ASC")
-    Slice<DonatorTotalDonationRepositoryDto> findDonatorRankings(Pageable pageable);
-
-    @Query("SELECT new com.example.mymoo.domain.donation.dto.response.DonatorTotalDonationRepositoryDto(" +
-        "d.account.id, d.account.nickname, d.account.profileImageUrl, SUM(d.point), MAX(d.createdAt)) " +
-        "FROM Donation d " +
-        "WHERE d.account.id = :accountId")
-    Optional<DonatorTotalDonationRepositoryDto> findTotalDonationByAccountId(@Param("accountId") Long accountId);
-
-
-    // 자신의 총 point보다 큰 계정 OR 총 point가 같고 자신보다 최근에 후원한 계정의 수 + 1 반환
-    @Query("SELECT COUNT(DISTINCT d2.account.id) + 1 FROM Donation d2 " +
-        "WHERE (" +
-        "    (SELECT SUM(d.point) FROM Donation d WHERE d.account.id = :accountId) < " +
-        "    (SELECT SUM(d3.point) FROM Donation d3 WHERE d3.account.id = d2.account.id) " +
-            "OR (" +
-            "    (SELECT SUM(d.point) FROM Donation d WHERE d.account.id = :accountId) = " +
-            "    (SELECT SUM(d3.point) FROM Donation d3 WHERE d3.account.id = d2.account.id) AND " +
-            "    (SELECT MAX(d.createdAt) FROM Donation d WHERE d.account.id = :accountId) < " +
-            "    (SELECT MAX(d4.createdAt) FROM Donation d4 WHERE d4.account.id = d2.account.id)" +
-            ")" +
-        ")"
-    )
-    Long findRankByAccountId(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/example/mymoo/domain/donation/repository/impl/CustomDonationRepositoryImpl.java
+++ b/src/main/java/com/example/mymoo/domain/donation/repository/impl/CustomDonationRepositoryImpl.java
@@ -1,0 +1,166 @@
+package com.example.mymoo.domain.donation.repository.impl;
+
+import com.example.mymoo.domain.account.entity.QAccount;
+import com.example.mymoo.domain.donation.dto.response.DonatorTotalDonationRepositoryDto;
+import com.example.mymoo.domain.donation.entity.Donation;
+import com.example.mymoo.domain.donation.entity.QDonation;
+import com.example.mymoo.domain.donation.repository.CustomDonationRepository;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class CustomDonationRepositoryImpl implements CustomDonationRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QDonation donation = QDonation.donation;
+    private final QAccount account = QAccount.account;
+
+    /**
+     * 주어진 accountId에 해당하는 기부 내역을 조회하며,
+     * 지정된 시작 날짜(startDate) 이후에 생성된 기부만 포함하고,
+     * 생성일(createdAt)을 기준으로 내림차순 정렬하여 반환합니다.
+     */
+    @Override
+    public Slice<Donation> findRecentDonationsByAccountId(
+        final Long accountId,
+        final LocalDateTime startDate,
+        final Pageable pageable
+    ) {
+        List<Donation> content = queryFactory
+            .selectFrom(donation)
+            .where(
+                donation.account.id.eq(accountId),
+                donation.createdAt.goe(startDate)
+            )
+            .orderBy(donation.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return createSlice(content, pageable);
+    }
+
+    /**
+     * 기부자 순위를 조회하며, 각 기부자의 총 기부 포인트와 마지막 기부 날짜를 기준으로 정렬합니다.
+     * 결과는 페이지네이션을 적용하여 반환합니다.
+     */
+    @Override
+    public Slice<DonatorTotalDonationRepositoryDto> findDonatorRankings(final Pageable pageable) {
+        List<DonatorTotalDonationRepositoryDto> content = queryFactory
+            .select(createDonatorTotalDonationProjection())
+            .from(donation)
+            .join(donation.account, account)
+            .groupBy(account.id, account.nickname, account.profileImageUrl)
+            .orderBy(donation.point.sum().desc(), donation.createdAt.max().desc(), account.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return createSlice(content, pageable);
+    }
+
+
+    /**
+     * 주어진 accountId에 해당하는 기부자의 총 기부 포인트와 마지막 기부 날짜를 조회하여 반환합니다.
+     */
+    @Override
+    public Optional<DonatorTotalDonationRepositoryDto> findTotalDonationByAccountId(final Long accountId) {
+        return Optional.ofNullable(queryFactory
+            .select(createDonatorTotalDonationProjection())
+            .from(donation)
+            .where(account.id.eq(accountId))
+            .join(donation.account, account)
+            .groupBy(account.id, account.nickname, account.profileImageUrl)
+            .fetchOne());
+    }
+
+    /**
+     * 자신의 총 포인트보다 큰 계정 또는 총 포인트가 같고 자신보다 최근에 후원한 계정의 수 + 1을 반환합니다.
+     */
+    @Override
+    public Long findRankByAccountId(final Long accountId) {
+        QDonation comparisonDonation = new QDonation("comparisonDonation");
+
+        JPQLQuery<Long> accountTotalPoints = getAccountTotalPoints(accountId);
+        JPQLQuery<LocalDateTime> accountLastDonationDate = getAccountLastDonationDate(accountId);
+
+        return queryFactory
+            .select(comparisonDonation.account.id.countDistinct().add(1))
+            .from(comparisonDonation)
+            .where(createRankingCondition(comparisonDonation, accountTotalPoints, accountLastDonationDate))
+            .fetchOne();
+    }
+
+    private BooleanExpression createRankingCondition(
+        QDonation comparisonDonation,
+        JPQLQuery<Long> accountTotalPoints,
+        JPQLQuery<LocalDateTime> accountLastDonationDate
+    ) {
+        return accountTotalPoints.lt(getTotalDonationPointSubquery(comparisonDonation.account.id))
+            .or(
+                accountTotalPoints.eq(getTotalDonationPointSubquery(comparisonDonation.account.id))
+                    .and(accountLastDonationDate.lt(getLastDonationDateSubquery(comparisonDonation.account.id)))
+            );
+    }
+
+    private JPQLQuery<Long> getAccountTotalPoints(Long accountId) {
+        return JPAExpressions
+            .select(donation.point.sum())
+            .from(donation)
+            .where(donation.account.id.eq(accountId));
+    }
+
+    private JPQLQuery<LocalDateTime> getAccountLastDonationDate(Long accountId) {
+        return JPAExpressions
+            .select(donation.createdAt.max())
+            .from(donation)
+            .where(donation.account.id.eq(accountId));
+    }
+
+    private ConstructorExpression<DonatorTotalDonationRepositoryDto> createDonatorTotalDonationProjection() {
+        return Projections.constructor(
+            DonatorTotalDonationRepositoryDto.class,
+            account.id,
+            account.nickname,
+            account.profileImageUrl,
+            donation.point.sum(),
+            donation.createdAt.max()
+        );
+    }
+
+    private <T> Slice<T> createSlice(List<T> content, Pageable pageable) {
+        boolean hasNext = content.size() > pageable.getPageSize();
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+
+    private JPAQuery<Long> getTotalDonationPointSubquery(NumberPath<Long> accountId) {
+        return queryFactory
+            .select(donation.point.sum())
+            .from(donation)
+            .where(donation.account.id.eq(accountId));
+    }
+
+    private JPAQuery<LocalDateTime> getLastDonationDateSubquery(NumberPath<Long> accountId) {
+        return queryFactory
+            .select(donation.createdAt.max())
+            .from(donation)
+            .where(donation.account.id.eq(accountId));
+    }
+}

--- a/src/main/java/com/example/mymoo/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/mymoo/global/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.example.mymoo.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #50

## 📝 Work Details
- Transitioned existing JPQL queries in the project to QueryDSL for improved type safety and dynamic query capabilities.
- Created a new `CustomDonationRepository` interface and extended the existing `DonationRepository` to include this custom repository.
- Implemented the `CustomDonationRepositoryImpl` class using QueryDSL to provide the necessary query functionalities.
- Ensured that all existing functionality remains intact and that the new implementations return the expected results.